### PR TITLE
Create v3.4.3 chart with changes for Red Hat (KUBEDR-5988)

### DIFF
--- a/charts/v3.4.3/Chart.yaml
+++ b/charts/v3.4.3/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: cloudcasa
+version: "3.4.2"
+appVersion: "3.1.0"
+kubeVersion: ">=1.20.0-0"
+description: CloudCasa backup service for Kubernetes and cloud-native applications. Offering CloudCasa Pro and CloudCasa Velero management services.
+home: https://cloudcasa.io
+icon: https://raw.githubusercontent.com/catalogicsoftware/cloudcasa-helmchart/gh-pages/logo.png
+keywords:
+  - backup
+  - restore
+  - migration
+  - catalogic
+  - cloudcasa
+  - velero
+maintainers:
+  - name: CloudCasa Support
+    email: support@cloudcasa.io

--- a/charts/v3.4.3/Chart.yaml
+++ b/charts/v3.4.3/Chart.yaml
@@ -1,9 +1,11 @@
 apiVersion: v2
 name: cloudcasa
-version: "3.4.2"
+version: "3.4.3"
 appVersion: "3.1.0"
 kubeVersion: ">=1.20.0-0"
-description: CloudCasa backup service for Kubernetes and cloud-native applications. Offering CloudCasa Pro and CloudCasa Velero management services.
+description: CloudCasa backup and migration service for Kubernetes and cloud-native applications.
+annotations:
+  charts.openshift.io/name: CloudCasa Agent
 home: https://cloudcasa.io
 icon: https://raw.githubusercontent.com/catalogicsoftware/cloudcasa-helmchart/gh-pages/logo.png
 keywords:

--- a/charts/v3.4.3/README.md
+++ b/charts/v3.4.3/README.md
@@ -36,7 +36,7 @@ See the CloudCasa [Getting Started Guide](https://cloudcasa.io/get-started) for 
     ```
 This will install the CloudCasa agent and complete registration of the cluster with the CloudCasa service.
 
-## Updating the CloudCasa Agent
+### Updating the CloudCasa Agent
 1. Log in to https://home.cloudcasa.io and obtain the cluster ID for your cluster by selecting it under the Protection tab. You can also obtain the current setting for it with the command ```helm get values cloudcasa```.
 2. Execute the following commands to update the agent, replacing ```<Cluster ID>``` with the Cluster ID obtained above:
     ```
@@ -44,7 +44,7 @@ This will install the CloudCasa agent and complete registration of the cluster w
     $ helm upgrade cloudcasa cloudcasa-repo/cloudcasa --set cluster_id=<Cluster ID>
     ```
 
-## Uninstalling the CloudCasa Agent
+### Uninstalling the CloudCasa Agent
 1. Execute the following commands to uninstall CloudCasa.
     ```    
     $ helm uninstall cloudcasa

--- a/charts/v3.4.3/README.md
+++ b/charts/v3.4.3/README.md
@@ -7,7 +7,7 @@
 CloudCasa is a SaaS data protection, disaster recovery, migration, and replication solution for Kubernetes and cloud-native applications. Configuration is quick and easy, and basic service is free.
 
 CloudCasa provides two types of backup services for Kubernetes: 
-* **CloudCasa Pro** provides centralized backup services for large, complex, multi-cluster, multi-cloud, and hybrid cloud environments. It includes multi-cloud account integration, managed backup storage, and advanced cross-cloud recovery.
+* **CloudCasa Pro** provides centralized backup, DR, and migration services for large, complex, multi-cluster, multi-cloud, and hybrid cloud environments. It includes multi-cloud account integration, managed backup storage, and advanced cross-cloud recovery.
 * **CloudCasa Velero Management** provides centralized management and monitoring, guided recovery, and commercial support for existing Velero backup installations.
 
 Whether you are managing existing Velero installations or using the advanced Pro features, with CloudCasa you don't need to be a storage or data protection expert to back up and restore your Kubernetes clusters.

--- a/charts/v3.4.3/README.md
+++ b/charts/v3.4.3/README.md
@@ -1,0 +1,52 @@
+# CloudCasa Kubernetes Agent
+
+[CloudCasa](https://cloudcasa.io) - Leader in Kubernetes Data Protection and Application Resiliency
+
+# Introduction
+
+CloudCasa is a SaaS data protection, disaster recovery, migration, and replication solution for Kubernetes and cloud-native applications. Configuration is quick and easy, and basic service is free.
+
+CloudCasa provides two types of backup services for Kubernetes: 
+* **CloudCasa Pro** provides centralized backup services for large, complex, multi-cluster, multi-cloud, and hybrid cloud environments. It includes multi-cloud account integration, managed backup storage, and advanced cross-cloud recovery.
+* **CloudCasa Velero Management** provides centralized management and monitoring, guided recovery, and commercial support for existing Velero backup installations.
+
+Whether you are managing existing Velero installations or using the advanced Pro features, with CloudCasa you don't need to be a storage or data protection expert to back up and restore your Kubernetes clusters.
+
+This Helm chart installs and configures the CloudCasa agent on a Kubernetes cluster.
+See the CloudCasa [Getting Started Guide](https://cloudcasa.io/get-started) for more information.
+
+## Prerequisites
+
+1. Kubernetes 1.20+
+2. Helm 3.0+
+
+## Installation
+ 
+### Installing the CloudCasa Agent
+
+1. Log in to https://home.cloudcasa.io and add your Kubernetes cluster under the Protection tab. Note the returned cluster ID.
+2. Add the CloudCasa Helm repo to your Helm configuration, if it hasn't been added already.
+   ```
+   $ helm repo add cloudcasa-repo https://catalogicsoftware.github.io/cloudcasa-helmchart
+   ```
+3. To install the agent, execute the following helm commands, replacing ```<Cluster ID>``` with the Cluster ID obtained above:
+    ```
+    $ helm repo update
+    $ helm install cloudcasa cloudcasa-repo/cloudcasa --set cluster_id=<Cluster ID>
+    ```
+This will install the CloudCasa agent and complete registration of the cluster with the CloudCasa service.
+
+## Updating the CloudCasa Agent
+1. Log in to https://home.cloudcasa.io and obtain the cluster ID for your cluster by selecting it under the Protection tab. You can also obtain the current setting for it with the command ```helm get values cloudcasa```.
+2. Execute the following commands to update the agent, replacing ```<Cluster ID>``` with the Cluster ID obtained above:
+    ```
+    $ helm repo update
+    $ helm upgrade cloudcasa cloudcasa-repo/cloudcasa --set cluster_id=<Cluster ID>
+    ```
+
+## Uninstalling the CloudCasa Agent
+1. Execute the following commands to uninstall CloudCasa.
+    ```    
+    $ helm uninstall cloudcasa
+    ```
+*CloudCasa is a trademark of Catalogic Software Inc.*

--- a/charts/v3.4.3/templates/NOTES.txt
+++ b/charts/v3.4.3/templates/NOTES.txt
@@ -1,0 +1,10 @@
+Please be patient while the CloudCasa agent is being deployed. It may take several minutes.
+
+The agent is configured with cluster ID: {{ .Values.cluster_id }}
+
+Once the agent completes startup, the state shown for the cluster in the CloudCasa Clusters/Overview
+page (https://home.cloudcasa.io/clusters/overview) will change to "Active".
+If the cluster stays in the "Registered" or "Pending" state, you may have provided the wrong ClusterID.
+
+You can check the agent deployment status using the command: kubectl get pods -n cloudcasa-io
+

--- a/charts/v3.4.3/templates/cluster-register.yaml
+++ b/charts/v3.4.3/templates/cluster-register.yaml
@@ -1,0 +1,99 @@
+---
+# This list contains the CloudCasa Agent Manager and RBAC resources 
+# required to deploy the Cloudcasa agent.
+apiVersion: v1
+kind: List
+metadata:
+  name: cloudcasa-agent
+items:
+{{- if not (lookup "v1" "Namespace" "cloudcasa-io" "cloudcasa-io") }}
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    creationTimestamp: null
+    labels:
+      component: kubeagent-backup-helper
+    name: cloudcasa-io
+  spec: {}
+{{- end }}
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    labels:
+      component: kubeagent-backup-helper
+    name: cloudcasa-io
+    namespace: cloudcasa-io
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    labels:
+      component: kubeagent-backup-helper
+    name: cloudcasa-io
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: cluster-admin
+  subjects:
+  - kind: ServiceAccount
+    name: cloudcasa-io
+    namespace: cloudcasa-io
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: cloudcasa-kubeagent-manager
+    namespace: cloudcasa-io
+    labels:
+      component: cloudcasa-kubeagent-manager
+  spec:
+    selector:
+      matchLabels:
+        app: cloudcasa-kubeagent-manager
+    strategy:
+      type: Recreate
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: cloudcasa-kubeagent-manager
+      spec:
+        containers:
+        - image: catalogicsoftware/amds-kagent:3.1.0-prod
+          args: ["/usr/local/bin/kubeagentmanager", "--server_addr", "agent.cloudcasa.io:443", "--tls", "true"]
+          name: kubeagentmanager
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "250m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+          volumeMounts:          
+          - mountPath: /scratch
+            name: scratch          
+          env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: AMDS_CLUSTER_ID
+            value: {{ .Values.cluster_id }}
+          - name: KUBEMOVER_IMAGE
+            value: catalogicsoftware/amds-kagent:3.1.0-prod
+          - name: DEPLOYMENT_PLATFORM
+            {{ if (lookup "v1" "Namespace" "" "cattle-system") }}
+            value: "rancher"
+            {{ else if (lookup "v1" "Namespace" "" "nirmata") }}
+            value: "nirmata"
+            {{ else if (lookup "v1" "Namespace" "" "rafay-system") }}
+            value: "rafay"
+            {{ else }}
+            value: "helm"
+            {{ end }}
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 0
+        serviceAccountName: cloudcasa-io
+        volumes:        
+        - emptyDir: {}
+          name: scratch

--- a/charts/v3.4.3/templates/cluster-register.yaml
+++ b/charts/v3.4.3/templates/cluster-register.yaml
@@ -59,7 +59,7 @@ items:
           app: cloudcasa-kubeagent-manager
       spec:
         containers:
-        - image: catalogicsoftware/amds-kagent:3.1.0-prod
+        - image: registry.connect.redhat.com/catalogicsoftware/cloudcasa-amds-kagent:3.5.7
           args: ["/usr/local/bin/kubeagentmanager", "--server_addr", "agent.cloudcasa.io:443", "--tls", "true"]
           name: kubeagentmanager
           resources:
@@ -80,7 +80,7 @@ items:
           - name: AMDS_CLUSTER_ID
             value: {{ .Values.cluster_id }}
           - name: KUBEMOVER_IMAGE
-            value: catalogicsoftware/amds-kagent:3.1.0-prod
+            value: registry.connect.redhat.com/catalogicsoftware/cloudcasa-amds-kagent:3.5.7
           - name: DEPLOYMENT_PLATFORM
             {{ if (lookup "v1" "Namespace" "" "cattle-system") }}
             value: "rancher"

--- a/charts/v3.4.3/templates/cluster-register.yaml
+++ b/charts/v3.4.3/templates/cluster-register.yaml
@@ -84,10 +84,6 @@ items:
           - name: DEPLOYMENT_PLATFORM
             {{ if (lookup "v1" "Namespace" "" "cattle-system") }}
             value: "rancher"
-            {{ else if (lookup "v1" "Namespace" "" "nirmata") }}
-            value: "nirmata"
-            {{ else if (lookup "v1" "Namespace" "" "rafay-system") }}
-            value: "rafay"
             {{ else }}
             value: "helm"
             {{ end }}

--- a/charts/v3.4.3/templates/tests/test-agent.yaml
+++ b/charts/v3.4.3/templates/tests/test-agent.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "cloudcasa-test-agent"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: kubeagentmanager-test
+      image: catalogicsoftware/amds-kagent:3.1.0-prod
+      command: ['curl']
+      args: ['']
+  restartPolicy: Never

--- a/charts/v3.4.3/templates/tests/test-agent.yaml
+++ b/charts/v3.4.3/templates/tests/test-agent.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: kubeagentmanager-test
-      image: catalogicsoftware/amds-kagent:3.1.0-prod
+      image: registry.connect.redhat.com/catalogicsoftware/cloudcasa-amds-kagent:3.5.7
       command: ["bin/bash", "-c"]
       args:
         - kubectl get deployment cloudcasa-kubeagent-manager

--- a/charts/v3.4.3/templates/tests/test-agent.yaml
+++ b/charts/v3.4.3/templates/tests/test-agent.yaml
@@ -2,12 +2,17 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "cloudcasa-test-agent"
+  namespace: cloudcasa-io
   annotations:
     "helm.sh/hook": test
 spec:
   containers:
     - name: kubeagentmanager-test
       image: catalogicsoftware/amds-kagent:3.1.0-prod
-      command: ['curl']
-      args: ['']
+      command: ["bin/bash", "-c"]
+      args:
+        - kubectl get deployment cloudcasa-kubeagent-manager
+        - -o=jsonpath='{.status.conditions[?(@.type=="Available")].status}' |
+        - grep -q "True"
+  serviceAccountName: cloudcasa-io
   restartPolicy: Never

--- a/charts/v3.4.3/values.schema.json
+++ b/charts/v3.4.3/values.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "properties": {
+    "cluster_id": {
+      "description": "Cluster ID",
+      "type": "string"
+    }
+  },
+  "title": "Values",
+  "type": "object"
+}

--- a/charts/v3.4.3/values.yaml
+++ b/charts/v3.4.3/values.yaml
@@ -1,0 +1,4 @@
+## Please note that this will override the parameters, including dependencies, configured to use the global value.
+
+## CloudCasa Cluster ID. To be provided by the user.
+cluster_id: ""

--- a/charts/v3.4.3/values.yaml
+++ b/charts/v3.4.3/values.yaml
@@ -1,4 +1,2 @@
-## Please note that this will override the parameters, including dependencies, configured to use the global value.
-
 ## CloudCasa Cluster ID. To be provided by the user.
 cluster_id: ""


### PR DESCRIPTION
Add new v3.4.3 chart with changes required for approval by Red Hat for their marketplace.

Red Hat requirements:
- [x] Chart must include one or more [tests](https://helm.sh/docs/topics/chart_tests/) located in the templates directory.
- [x] Chart must include a values.schema.json file.
- [x] Chart must include the charts.openshift.io/name annotation with a human-readable name.

Other items:
- [ ] Add DEPLOYMENT_PLATFORM identifier for Red Hat in cluster-register.yaml
- [ ] Investigate adding support for cluster ID secret
- [ ] Add support for self-hosted
- [ ] Add support for alternate container repo