### PR TITLE
Create V3.4.4 chart

### DIFF
--- a/charts/v3.4.4/Chart.yaml
+++ b/charts/v3.4.4/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: cloudcasa
+version: "3.4.4"
+appVersion: "3.1.0"
+kubeVersion: ">=1.20.0-0"
+description: CloudCasa backup and migration service agent for Kubernetes and cloud-native applications
+annotations:
+  charts.openshift.io/name: CloudCasa Agent
+home: https://cloudcasa.io
+icon: https://raw.githubusercontent.com/catalogicsoftware/cloudcasa-helmchart/gh-pages/logo.png
+keywords:
+  - backup
+  - restore
+  - migration
+  - catalogic
+  - cloudcasa
+  - velero
+maintainers:
+  - name: CloudCasa Support
+    email: support@cloudcasa.io

--- a/charts/v3.4.4/Chart.yaml
+++ b/charts/v3.4.4/Chart.yaml
@@ -3,7 +3,7 @@ name: cloudcasa
 version: "3.4.4"
 appVersion: "3.1.0"
 kubeVersion: ">=1.20.0-0"
-description: CloudCasa backup and migration service agent for Kubernetes and cloud-native applications
+description: CloudCasa backup and migration service agent for Kubernetes
 annotations:
   charts.openshift.io/name: CloudCasa Agent
 home: https://cloudcasa.io

--- a/charts/v3.4.4/README.md
+++ b/charts/v3.4.4/README.md
@@ -49,7 +49,13 @@ This will install the CloudCasa agent and complete registration of the cluster w
     ```    
     $ helm uninstall cloudcasa
     ```
-###Using an alternate image repository
+
+2. If you manually created the cloudcasa-io namespace in order to supply a container registry authentication secret (see below),
+you may need to manually delete the namesapce after uninstall with the command `kubectl delete namespace cloudcasa-io`.
+
+3. CloudCasa creates some custom resource definitions on installation, which you can remove manually with the command `kubectl delete crd -l component=kubeagent-backup-helper`.
+
+### Using an alternate image repository
 
 The agent manager container can be installed from an alternate repository by setting values for image.repository and image.tag.
 Add the options --set image.repository=<repository> and/or --set image.tag=<tag> to the helm install command.

--- a/charts/v3.4.4/README.md
+++ b/charts/v3.4.4/README.md
@@ -24,7 +24,7 @@ See the CloudCasa [Getting Started Guide](https://cloudcasa.io/get-started) for 
  
 ### Installing the CloudCasa Agent
 
-1. Log in to https://home.cloudcasa.io and add your Kubernetes cluster under the Protection tab. Note the returned cluster ID.
+1. Log in to https://home.cloudcasa.io and add your Kubernetes cluster under Clusters/Overview. Note the returned cluster ID.
 2. Add the CloudCasa Helm repo to your Helm configuration, if it hasn't been added already.
    ```
    $ helm repo add cloudcasa-repo https://catalogicsoftware.github.io/cloudcasa-helmchart
@@ -37,7 +37,7 @@ See the CloudCasa [Getting Started Guide](https://cloudcasa.io/get-started) for 
 This will install the CloudCasa agent and complete registration of the cluster with the CloudCasa service.
 
 ### Updating the CloudCasa Agent
-1. Log in to https://home.cloudcasa.io and obtain the cluster ID for your cluster by selecting it under the Protection tab. You can also obtain the current setting for it with the command ```helm get values cloudcasa```.
+1. Log in to https://home.cloudcasa.io and obtain the cluster ID for your cluster by selecting it under Clusters/Overview. You can also obtain the current setting for it with the command ```helm get values cloudcasa```.
 2. Execute the following commands to update the agent, replacing ```<Cluster ID>``` with the Cluster ID obtained above:
     ```
     $ helm repo update
@@ -64,4 +64,4 @@ See the [Kubernetes Docs](https://kubernetes.io/docs/tasks/configure-pod-contain
 Note that the secret name will also need to be set for the cluster in CloudCasa so that it will be used for all agent containers.
 See the [CloudCasa User Guide](https://docs.cloudcasa.io/help/cluster-add.html) for more information.
 
-*CloudCasa is a trademark of Catalogic Software Inc.*
+*CloudCasa is a trademark of Catalogic Software, Inc.*

--- a/charts/v3.4.4/README.md
+++ b/charts/v3.4.4/README.md
@@ -1,6 +1,6 @@
 # CloudCasa Kubernetes Agent
 
-[CloudCasa](https://cloudcasa.io) - Leader in Kubernetes Data Protection and Application Resiliency
+[CloudCasa](https://cloudcasa.io) - Leader in Kubernetes Data Protection and Application Resilience
 
 # Introduction
 

--- a/charts/v3.4.4/README.md
+++ b/charts/v3.4.4/README.md
@@ -1,0 +1,52 @@
+# CloudCasa Kubernetes Agent
+
+[CloudCasa](https://cloudcasa.io) - Leader in Kubernetes Data Protection and Application Resiliency
+
+# Introduction
+
+CloudCasa is a SaaS data protection, disaster recovery, migration, and replication solution for Kubernetes and cloud-native applications. Configuration is quick and easy, and basic service is free.
+
+CloudCasa provides two types of backup services for Kubernetes: 
+* **CloudCasa Pro** provides centralized backup, DR, and migration services for large, complex, multi-cluster, multi-cloud, and hybrid cloud environments. It includes multi-cloud account integration, managed backup storage, and advanced cross-cloud recovery.
+* **CloudCasa Velero Management** provides centralized management and monitoring, guided recovery, and commercial support for existing Velero backup installations.
+
+Whether you are managing existing Velero installations or using the advanced Pro features, with CloudCasa you don't need to be a storage or data protection expert to back up and restore your Kubernetes clusters.
+
+This Helm chart installs and configures the CloudCasa agent on a Kubernetes cluster.
+See the CloudCasa [Getting Started Guide](https://cloudcasa.io/get-started) for more information.
+
+## Prerequisites
+
+1. Kubernetes 1.20+
+2. Helm 3.0+
+
+## Installation
+ 
+### Installing the CloudCasa Agent
+
+1. Log in to https://home.cloudcasa.io and add your Kubernetes cluster under the Protection tab. Note the returned cluster ID.
+2. Add the CloudCasa Helm repo to your Helm configuration, if it hasn't been added already.
+   ```
+   $ helm repo add cloudcasa-repo https://catalogicsoftware.github.io/cloudcasa-helmchart
+   ```
+3. To install the agent, execute the following helm commands, replacing ```<Cluster ID>``` with the Cluster ID obtained above:
+    ```
+    $ helm repo update
+    $ helm install cloudcasa cloudcasa-repo/cloudcasa --set cluster_id=<Cluster ID>
+    ```
+This will install the CloudCasa agent and complete registration of the cluster with the CloudCasa service.
+
+### Updating the CloudCasa Agent
+1. Log in to https://home.cloudcasa.io and obtain the cluster ID for your cluster by selecting it under the Protection tab. You can also obtain the current setting for it with the command ```helm get values cloudcasa```.
+2. Execute the following commands to update the agent, replacing ```<Cluster ID>``` with the Cluster ID obtained above:
+    ```
+    $ helm repo update
+    $ helm upgrade cloudcasa cloudcasa-repo/cloudcasa --set cluster_id=<Cluster ID>
+    ```
+
+### Uninstalling the CloudCasa Agent
+1. Execute the following commands to uninstall CloudCasa.
+    ```    
+    $ helm uninstall cloudcasa
+    ```
+*CloudCasa is a trademark of Catalogic Software Inc.*

--- a/charts/v3.4.4/README.md
+++ b/charts/v3.4.4/README.md
@@ -60,8 +60,10 @@ See the [CloudCasa User Guide](https://docs.cloudcasa.io/help/cluster-add.html) 
 If the registry you are using requires authentication, you can define a Kubernetes secret with the authentication information
 and reference it by setting a value for imagePullSecret. Example: "--set imagePullSecret=registrySecret".
 See the [Kubernetes Docs](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) for more information.
+Note that the secret must be created in the cloudcasa-io namespace, so you may need to create the namespace first.
+Also note that when uninstalling the agent, you may need to delete the cloudcasa-io namespace manually after running helm uninstall with "kubectl delete namespace cloudcasa-io".
 
-Note that the secret name will also need to be set for the cluster in CloudCasa so that it will be used for all agent containers.
+Finally, the secret name will also need to be set in CloudCasa for the cluster, so that it will be used for all agent containers.
 See the [CloudCasa User Guide](https://docs.cloudcasa.io/help/cluster-add.html) for more information.
 
 *CloudCasa is a trademark of Catalogic Software, Inc.*

--- a/charts/v3.4.4/README.md
+++ b/charts/v3.4.4/README.md
@@ -51,7 +51,7 @@ This will install the CloudCasa agent and complete registration of the cluster w
     ```
 
 2. If you manually created the cloudcasa-io namespace in order to supply a container registry authentication secret (see below),
-you may need to manually delete the namesapce after uninstall with the command `kubectl delete namespace cloudcasa-io`.
+you may need to manually delete the namespace after uninstall with the command `kubectl delete namespace cloudcasa-io`.
 
 3. CloudCasa creates some custom resource definitions on installation, which you can remove manually with the command `kubectl delete crd -l component=kubeagent-backup-helper`.
 

--- a/charts/v3.4.4/README.md
+++ b/charts/v3.4.4/README.md
@@ -32,7 +32,7 @@ See the CloudCasa [Getting Started Guide](https://cloudcasa.io/get-started) for 
 3. To install the agent, execute the following helm commands, replacing ```<Cluster ID>``` with the Cluster ID obtained above:
     ```
     $ helm repo update
-    $ helm install cloudcasa cloudcasa-repo/cloudcasa --set cluster_id=<Cluster ID>
+    $ helm install cloudcasa cloudcasa-repo/cloudcasa --set clusterID=<Cluster ID>
     ```
 This will install the CloudCasa agent and complete registration of the cluster with the CloudCasa service.
 
@@ -41,7 +41,7 @@ This will install the CloudCasa agent and complete registration of the cluster w
 2. Execute the following commands to update the agent, replacing ```<Cluster ID>``` with the Cluster ID obtained above:
     ```
     $ helm repo update
-    $ helm upgrade cloudcasa cloudcasa-repo/cloudcasa --set cluster_id=<Cluster ID>
+    $ helm upgrade cloudcasa cloudcasa-repo/cloudcasa --set clusterID=<Cluster ID>
     ```
 
 ### Uninstalling the CloudCasa Agent

--- a/charts/v3.4.4/README.md
+++ b/charts/v3.4.4/README.md
@@ -49,4 +49,19 @@ This will install the CloudCasa agent and complete registration of the cluster w
     ```    
     $ helm uninstall cloudcasa
     ```
+###Using an alternate image repository
+
+The agent manager container can be installed from an alternate repository by setting values for image.repository and image.tag.
+Add the options --set image.repository=<repository> and/or --set image.tag=<tag> to the helm install command.
+
+Note that the alternate repository will also need to be set for the cluster in CloudCasa so that all agent containers will be loaded from it.
+See the [CloudCasa User Guide](https://docs.cloudcasa.io/help/cluster-add.html) for more information.
+
+If the registry you are using requires authentication, you can define a Kubernetes secret with the authentication information
+and reference it by setting a value for imagePullSecret. Example: "--set imagePullSecret=registrySecret".
+See the [Kubernetes Docs](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) for more information.
+
+Note that the secret name will also need to be set for the cluster in CloudCasa so that it will be used for all agent containers.
+See the [CloudCasa User Guide](https://docs.cloudcasa.io/help/cluster-add.html) for more information.
+
 *CloudCasa is a trademark of Catalogic Software Inc.*

--- a/charts/v3.4.4/templates/NOTES.txt
+++ b/charts/v3.4.4/templates/NOTES.txt
@@ -1,0 +1,10 @@
+Please be patient while the CloudCasa agent is being deployed. It may take several minutes.
+
+The agent is configured with cluster ID: {{ .Values.cluster_id }}
+
+Once the agent completes startup, the state shown for the cluster in the CloudCasa Clusters/Overview
+page (https://home.cloudcasa.io/clusters/overview) will change to "Active".
+If the cluster stays in the "Registered" or "Pending" state, you may have provided the wrong ClusterID.
+
+You can check the agent deployment status using the command: kubectl get pods -n cloudcasa-io
+

--- a/charts/v3.4.4/templates/NOTES.txt
+++ b/charts/v3.4.4/templates/NOTES.txt
@@ -1,6 +1,6 @@
 Please be patient while the CloudCasa agent is being deployed. It may take several minutes.
 
-The agent is configured with cluster ID: {{ .Values.cluster_id }}
+The agent is configured with cluster ID: {{ .Values.clusterID }}
 
 Once the agent completes startup, the state shown for the cluster in the CloudCasa Clusters/Overview
 page (https://home.cloudcasa.io/clusters/overview) will change to "Active".

--- a/charts/v3.4.4/templates/cluster-register.yaml
+++ b/charts/v3.4.4/templates/cluster-register.yaml
@@ -58,8 +58,12 @@ items:
         labels:
           app: cloudcasa-kubeagent-manager
       spec:
+        {{ if .Values.imagePullSecret }}
+        imagePullSecrets:
+          - name: {{ .Values.imagePullSecret | quote }}
+        {{ end }}
         containers:
-        - image: "{{ .Values.repository }}:3.1.0-prod"
+        - image: "{{ .Values.repository }}:{{ .Values.tag }}"
           args: ["/usr/local/bin/kubeagentmanager", "--server_addr", "agent.cloudcasa.io:443", "--tls", "true"]
           name: kubeagentmanager
           resources:
@@ -80,7 +84,7 @@ items:
           - name: AMDS_CLUSTER_ID
             value: {{ .Values.clusterID }}
           - name: KUBEMOVER_IMAGE
-            value: catalogicsoftware/amds-kagent:3.1.0-prod
+            value: {{ .Values.repository }}:{{ .Values.tag }}
           - name: DEPLOYMENT_PLATFORM
             {{ if (lookup "v1" "Namespace" "" "cattle-system") }}
             value: "rancher"

--- a/charts/v3.4.4/templates/cluster-register.yaml
+++ b/charts/v3.4.4/templates/cluster-register.yaml
@@ -1,0 +1,95 @@
+---
+# This list contains the CloudCasa Agent Manager and RBAC resources 
+# required to deploy the Cloudcasa agent.
+apiVersion: v1
+kind: List
+metadata:
+  name: cloudcasa-agent
+items:
+{{- if not (lookup "v1" "Namespace" "cloudcasa-io" "cloudcasa-io") }}
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    creationTimestamp: null
+    labels:
+      component: kubeagent-backup-helper
+    name: cloudcasa-io
+  spec: {}
+{{- end }}
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    creationTimestamp: null
+    labels:
+      component: kubeagent-backup-helper
+    name: cloudcasa-io
+    namespace: cloudcasa-io
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    labels:
+      component: kubeagent-backup-helper
+    name: cloudcasa-io
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: cluster-admin
+  subjects:
+  - kind: ServiceAccount
+    name: cloudcasa-io
+    namespace: cloudcasa-io
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: cloudcasa-kubeagent-manager
+    namespace: cloudcasa-io
+    labels:
+      component: cloudcasa-kubeagent-manager
+  spec:
+    selector:
+      matchLabels:
+        app: cloudcasa-kubeagent-manager
+    strategy:
+      type: Recreate
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: cloudcasa-kubeagent-manager
+      spec:
+        containers:
+        - image: registry.connect.redhat.com/catalogicsoftware/cloudcasa-amds-kagent:3.5.7
+          args: ["/usr/local/bin/kubeagentmanager", "--server_addr", "agent.cloudcasa.io:443", "--tls", "true"]
+          name: kubeagentmanager
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "250m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+          volumeMounts:          
+          - mountPath: /scratch
+            name: scratch          
+          env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: AMDS_CLUSTER_ID
+            value: {{ .Values.cluster_id }}
+          - name: KUBEMOVER_IMAGE
+            value: registry.connect.redhat.com/catalogicsoftware/cloudcasa-amds-kagent:3.5.7
+          - name: DEPLOYMENT_PLATFORM
+            {{ if (lookup "v1" "Namespace" "" "cattle-system") }}
+            value: "rancher"
+            {{ else }}
+            value: "helm"
+            {{ end }}
+        restartPolicy: Always
+        terminationGracePeriodSeconds: 0
+        serviceAccountName: cloudcasa-io
+        volumes:        
+        - emptyDir: {}
+          name: scratch

--- a/charts/v3.4.4/templates/cluster-register.yaml
+++ b/charts/v3.4.4/templates/cluster-register.yaml
@@ -59,7 +59,7 @@ items:
           app: cloudcasa-kubeagent-manager
       spec:
         containers:
-        - image: catalogicsoftware/amds-kagent:3.1.0-prod
+        - image: "{{ .Values.repository }}:3.1.0-prod"
           args: ["/usr/local/bin/kubeagentmanager", "--server_addr", "agent.cloudcasa.io:443", "--tls", "true"]
           name: kubeagentmanager
           resources:
@@ -78,7 +78,7 @@ items:
               fieldRef:
                 fieldPath: metadata.name
           - name: AMDS_CLUSTER_ID
-            value: {{ .Values.cluster_id }}
+            value: {{ .Values.clusterID }}
           - name: KUBEMOVER_IMAGE
             value: catalogicsoftware/amds-kagent:3.1.0-prod
           - name: DEPLOYMENT_PLATFORM

--- a/charts/v3.4.4/templates/cluster-register.yaml
+++ b/charts/v3.4.4/templates/cluster-register.yaml
@@ -59,7 +59,7 @@ items:
           app: cloudcasa-kubeagent-manager
       spec:
         containers:
-        - image: registry.connect.redhat.com/catalogicsoftware/cloudcasa-amds-kagent:3.5.7
+        - image: catalogicsoftware/amds-kagent:3.1.0-prod
           args: ["/usr/local/bin/kubeagentmanager", "--server_addr", "agent.cloudcasa.io:443", "--tls", "true"]
           name: kubeagentmanager
           resources:
@@ -80,7 +80,7 @@ items:
           - name: AMDS_CLUSTER_ID
             value: {{ .Values.cluster_id }}
           - name: KUBEMOVER_IMAGE
-            value: registry.connect.redhat.com/catalogicsoftware/cloudcasa-amds-kagent:3.5.7
+            value: catalogicsoftware/amds-kagent:3.1.0-prod
           - name: DEPLOYMENT_PLATFORM
             {{ if (lookup "v1" "Namespace" "" "cattle-system") }}
             value: "rancher"

--- a/charts/v3.4.4/templates/cluster-register.yaml
+++ b/charts/v3.4.4/templates/cluster-register.yaml
@@ -63,7 +63,7 @@ items:
           - name: {{ .Values.imagePullSecret | quote }}
         {{ end }}
         containers:
-        - image: "{{ .Values.repository }}:{{ .Values.tag }}"
+        - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           args: ["/usr/local/bin/kubeagentmanager", "--server_addr", "agent.cloudcasa.io:443", "--tls", "true"]
           name: kubeagentmanager
           resources:
@@ -84,7 +84,7 @@ items:
           - name: AMDS_CLUSTER_ID
             value: {{ .Values.clusterID }}
           - name: KUBEMOVER_IMAGE
-            value: {{ .Values.repository }}:{{ .Values.tag }}
+            value: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           - name: DEPLOYMENT_PLATFORM
             {{ if (lookup "v1" "Namespace" "" "cattle-system") }}
             value: "rancher"

--- a/charts/v3.4.4/templates/tests/test-agent.yaml
+++ b/charts/v3.4.4/templates/tests/test-agent.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: kubeagentmanager-test
-      image: registry.connect.redhat.com/catalogicsoftware/cloudcasa-amds-kagent:3.5.7
+      image: catalogicsoftware/amds-kagent:3.1.0-prod
       command: ["bin/bash", "-c"]
       args:
         - kubectl get deployment cloudcasa-kubeagent-manager

--- a/charts/v3.4.4/templates/tests/test-agent.yaml
+++ b/charts/v3.4.4/templates/tests/test-agent.yaml
@@ -12,7 +12,7 @@ spec:
   {{ end }}
   containers:
     - name: kubeagentmanager-test
-      image: {{ .Values.repository }}:{{ .Values.tag }}
+      image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
       command: ["bin/bash", "-c"]
       args:
         - kubectl get deployment cloudcasa-kubeagent-manager

--- a/charts/v3.4.4/templates/tests/test-agent.yaml
+++ b/charts/v3.4.4/templates/tests/test-agent.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "cloudcasa-test-agent"
+  namespace: cloudcasa-io
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: kubeagentmanager-test
+      image: registry.connect.redhat.com/catalogicsoftware/cloudcasa-amds-kagent:3.5.7
+      command: ["bin/bash", "-c"]
+      args:
+        - kubectl get deployment cloudcasa-kubeagent-manager
+        - -o=jsonpath='{.status.conditions[?(@.type=="Available")].status}' |
+        - grep -q "True"
+  serviceAccountName: cloudcasa-io
+  restartPolicy: Never

--- a/charts/v3.4.4/templates/tests/test-agent.yaml
+++ b/charts/v3.4.4/templates/tests/test-agent.yaml
@@ -6,9 +6,13 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  {{ if .Values.imagePullSecret }}
+  imagePullSecrets:
+    - name: {{ .Values.imagePullSecret | quote }}
+  {{ end }}
   containers:
     - name: kubeagentmanager-test
-      image: catalogicsoftware/amds-kagent:3.1.0-prod
+      image: {{ .Values.repository }}:{{ .Values.tag }}
       command: ["bin/bash", "-c"]
       args:
         - kubectl get deployment cloudcasa-kubeagent-manager

--- a/charts/v3.4.4/values.schema.json
+++ b/charts/v3.4.4/values.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "properties": {
+    "cluster_id": {
+      "description": "Cluster ID",
+      "type": "string"
+    }
+  },
+  "title": "Values",
+  "type": "object"
+}

--- a/charts/v3.4.4/values.schema.json
+++ b/charts/v3.4.4/values.schema.json
@@ -8,10 +8,19 @@
     "repository": {
       "description": "Container repository",
       "type": "string"
+    },
+    "tag": {
+      "description": "Container version tag",
+      "type": "string"
+    },
+    "imagePullSecret": {
+      "description": "Name of secret to use for image registry credentials",
+      "type": ["string", "null"]
     }
   },
   "required": [
-    "repository"
+    "repository",
+    "tag"
   ],
   "title": "Values",
   "type": "object"

--- a/charts/v3.4.4/values.schema.json
+++ b/charts/v3.4.4/values.schema.json
@@ -1,27 +1,29 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Values",
+  "type": "object",
   "properties": {
     "clusterID": {
       "description": "Cluster ID",
       "type": "string"
     },
-    "repository": {
-      "description": "Container repository",
-      "type": "string"
-    },
-    "tag": {
-      "description": "Container version tag",
-      "type": "string"
+    "image": {
+      "description": "Container Image",
+      "type": "object",
+      "properties": {
+        "repository": {
+	  "type": "string"
+	},
+        "tag": {
+          "type": "string"
+        }
+      },
+      "required": [ "repository", "tag" ]
     },
     "imagePullSecret": {
       "description": "Name of secret to use for image registry credentials",
       "type": ["string", "null"]
     }
   },
-  "required": [
-    "repository",
-    "tag"
-  ],
-  "title": "Values",
-  "type": "object"
+  "required": [ "image" ]
 }

--- a/charts/v3.4.4/values.schema.json
+++ b/charts/v3.4.4/values.schema.json
@@ -1,11 +1,18 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "properties": {
-    "cluster_id": {
+    "clusterID": {
       "description": "Cluster ID",
+      "type": "string"
+    },
+    "repository": {
+      "description": "Container repository",
       "type": "string"
     }
   },
+  "required": [
+    "repository"
+  ],
   "title": "Values",
   "type": "object"
 }

--- a/charts/v3.4.4/values.yaml
+++ b/charts/v3.4.4/values.yaml
@@ -1,2 +1,4 @@
-## CloudCasa Cluster ID. To be provided by the user.
-cluster_id: ""
+# clusterID is the CloudCasa Cluster ID. To be provided by the user.
+clusterID: ""
+# repository is the container repo for the agent manager image
+repository: "docker.io/catalogicsoftware/amds-kagent"

--- a/charts/v3.4.4/values.yaml
+++ b/charts/v3.4.4/values.yaml
@@ -8,4 +8,5 @@ repository: "docker.io/catalogicsoftware/amds-kagent"
 tag: "3.1.0-prod"
 
 # imagePullSecret is the name of the secret to use for image registry credentials (optional)
-imagePullSecret: ""
+imagePullSecret:
+

--- a/charts/v3.4.4/values.yaml
+++ b/charts/v3.4.4/values.yaml
@@ -1,0 +1,2 @@
+## CloudCasa Cluster ID. To be provided by the user.
+cluster_id: ""

--- a/charts/v3.4.4/values.yaml
+++ b/charts/v3.4.4/values.yaml
@@ -8,4 +8,3 @@ image:
 
 # imagePullSecret is the name of the secret to use for image registry credentials (optional)
 imagePullSecret:
-

--- a/charts/v3.4.4/values.yaml
+++ b/charts/v3.4.4/values.yaml
@@ -1,11 +1,10 @@
 # clusterID is the CloudCasa Cluster ID. To be provided by the user.
 clusterID: ""
 
-# repository is the container repo for the agent manager
-repository: "docker.io/catalogicsoftware/amds-kagent"
-
-# tag is the version tag for the agent manager
-tag: "3.1.0-prod"
+# image is the container repository and tag for the agent manager
+image:
+  repository: "docker.io/catalogicsoftware/amds-kagent"
+  tag: "3.1.0-prod"
 
 # imagePullSecret is the name of the secret to use for image registry credentials (optional)
 imagePullSecret:

--- a/charts/v3.4.4/values.yaml
+++ b/charts/v3.4.4/values.yaml
@@ -1,4 +1,11 @@
 # clusterID is the CloudCasa Cluster ID. To be provided by the user.
 clusterID: ""
-# repository is the container repo for the agent manager image
+
+# repository is the container repo for the agent manager
 repository: "docker.io/catalogicsoftware/amds-kagent"
+
+# tag is the version tag for the agent manager
+tag: "3.1.0-prod"
+
+# imagePullSecret is the name of the secret to use for image registry credentials (optional)
+imagePullSecret: ""


### PR DESCRIPTION
The 3.4.4 version merges in all of the changes from the Red Hat-specific 3.4.3 version with the exception of the repo change.
New image.repository and image.tag parameters are now available as well as imagePullSecret for use with repos that require authentication. The cluster_id parameter has been changed to clusterID to conform with Helm naming best practices.
